### PR TITLE
Ignore duplicate files in wheel

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   release:
     types:
       - published

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,8 @@ packages = ["airflow-stubs"]
 source = "vcs"
 # Ensure that the version number is of the form vX.Y.Z
 tag-pattern = '''^v(\d+\.\d+\.\d+)$'''
+
+[tool.check-wheel-contents]
+ignore = [
+  "W002", # Wheel contains duplicate files
+]


### PR DESCRIPTION
Trying to solve the build failure in the check-wheel-contents part of the build-and-inspect-python-package action

```
/tmp/baipp/dist/airflow_stubs-0.0.2.dev5+g9cb55cf-py3-none-any.whl: W002: Wheel contains duplicate files:
  airflow-stubs/api/auth/backend/basic_auth.pyi
  airflow-stubs/auth/managers/fab/api/auth/backend/basic_auth.pyi
/tmp/baipp/dist/airflow_stubs-0.0.2.dev5+g9cb55cf-py3-none-any.whl: W002: Wheel contains duplicate files:
  airflow-stubs/api/auth/backend/default.pyi
  airflow-stubs/api/auth/backend/deny_all.pyi
/tmp/baipp/dist/airflow_stubs-0.0.2.dev5+g9cb55cf-py3-none-any.whl: W002: Wheel contains duplicate files:
  airflow-stubs/config_templates/__init__.pyi
  airflow-stubs/contrib/utils/log/__init__.pyi
  airflow-stubs/executors/__init__.pyi
  airflow-stubs/hooks/__init__.pyi
  airflow-stubs/kubernetes/__init__.pyi
  airflow-stubs/operators/__init__.pyi
  airflow-stubs/sensors/__init__.pyi
  airflow-stubs/utils/log/__init__.pyi
/tmp/baipp/dist/airflow_stubs-0.0.2.dev5+g9cb55cf-py3-none-any.whl: W002: Wheel contains duplicate files:
  airflow-stubs/contrib/hooks/__init__.pyi
  airflow-stubs/contrib/operators/__init__.pyi
  airflow-stubs/contrib/secrets/__init__.pyi
  airflow-stubs/contrib/sensors/__init__.pyi
  airflow-stubs/contrib/task_runner/__init__.pyi
  airflow-stubs/contrib/utils/__init__.pyi
/tmp/baipp/dist/airflow_stubs-0.0.2.dev5+g9cb55cf-py3-none-any.whl: W002: Wheel contains duplicate files:
  airflow-stubs/migrations/versions/0003_1_5_0_for_compatibility.pyi
  airflow-stubs/migrations/versions/0004_1_5_0_more_logging_into_task_isntance.pyi
  airflow-stubs/migrations/versions/0005_1_5_2_job_id_indices.pyi
  airflow-stubs/migrations/versions/0006_1_6_0_adding_extra_to_log.pyi
  airflow-stubs/migrations/versions/0008_1_6_0_task_duration.pyi
  airflow-stubs/migrations/versions/0009_1_6_0_dagrun_config.pyi
  airflow-stubs/migrations/versions/0010_1_6_2_add_password_column_to_user.pyi
  airflow-stubs/migrations/versions/0011_1_6_2_dagrun_start_end.pyi
  airflow-stubs/migrations/versions/0012_1_7_0_add_notification_sent_column_to_sla_miss.pyi
  airflow-stubs/migrations/versions/0013_1_7_0_add_a_column_to_track_the_encryption_.pyi
  airflow-stubs/migrations/versions/0014_1_7_0_add_is_encrypted_column_to_variable_.pyi
  airflow-stubs/migrations/versions/0015_1_7_1_rename_user_table.pyi
  airflow-stubs/migrations/versions/0016_1_7_1_add_ti_state_index.pyi
  airflow-stubs/migrations/versions/0019_1_7_1_add_fractional_seconds_to_mysql_tables.pyi
  airflow-stubs/migrations/versions/0020_1_7_1_xcom_dag_task_indices.pyi
  airflow-stubs/migrations/versions/0021_1_7_1_add_pid_field_to_taskinstance.pyi
  airflow-stubs/migrations/versions/0022_1_7_1_add_dag_id_state_index_on_dag_run_table.pyi
  airflow-stubs/migrations/versions/0024_1_8_2_make_xcom_value_column_a_large_binary.pyi
  airflow-stubs/migrations/versions/0025_1_8_2_add_ti_job_id_index.pyi
  airflow-stubs/migrations/versions/0026_1_8_2_increase_text_size_for_mysql.pyi
  airflow-stubs/migrations/versions/0032_1_10_0_fix_mysql_not_null_constraint.pyi
  airflow-stubs/migrations/versions/0033_1_10_0_fix_sqlite_foreign_key.pyi
  airflow-stubs/migrations/versions/0034_1_10_0_index_taskfail.pyi
  airflow-stubs/migrations/versions/0035_1_10_2_add_idx_log_dag.pyi
  airflow-stubs/migrations/versions/0036_1_10_2_add_index_to_taskinstance.pyi
  airflow-stubs/migrations/versions/0039_1_10_2_add_superuser_field.pyi
  airflow-stubs/migrations/versions/0040_1_10_3_add_fields_to_dag.pyi
  airflow-stubs/migrations/versions/0041_1_10_3_add_schedule_interval_to_dag.pyi
  airflow-stubs/migrations/versions/0042_1_10_3_task_reschedule_fk_on_cascade_delete.pyi
  airflow-stubs/migrations/versions/0047_1_10_4_increase_queue_name_size_limit.pyi
  airflow-stubs/migrations/versions/0048_1_10_3_remove_dag_stat_table.pyi
  airflow-stubs/migrations/versions/0050_1_10_7_increase_length_for_connection_password.pyi
  airflow-stubs/migrations/versions/0052_1_10_10_add_pool_slots_field_to_task_instance.pyi
  airflow-stubs/migrations/versions/0056_1_10_12_add_dag_hash_column_to_serialized_dag_.pyi
  airflow-stubs/migrations/versions/0057_1_10_13_add_fab_tables.pyi
  airflow-stubs/migrations/versions/0059_2_0_0_drop_user_and_chart.pyi
  airflow-stubs/migrations/versions/0063_2_0_0_set_conn_type_as_non_nullable.pyi
  airflow-stubs/migrations/versions/0066_2_0_0_add_queued_by_job_id_to_ti.pyi
  airflow-stubs/migrations/versions/0067_2_0_0_add_external_executor_id_to_ti.pyi
  airflow-stubs/migrations/versions/0071_2_0_0_add_job_id_to_dagrun_table.pyi
  airflow-stubs/migrations/versions/0075_2_0_0_add_description_field_to_connection.pyi
  airflow-stubs/migrations/versions/0076_2_0_0_fix_description_field_in_connection_to_.pyi
  airflow-stubs/migrations/versions/0077_2_0_0_change_field_in_dagcode_to_mediumtext_.pyi
  airflow-stubs/migrations/versions/0079_2_0_2_increase_size_of_connection_extra_field_.pyi
  airflow-stubs/migrations/versions/0080_2_0_2_change_default_pool_slots_to_1.pyi
  airflow-stubs/migrations/versions/0081_2_0_2_rename_last_scheduler_run_column.pyi
  airflow-stubs/migrations/versions/0082_2_1_0_increase_pool_name_size_in_taskinstance.pyi
  airflow-stubs/migrations/versions/0083_2_1_0_add_description_field_to_variable.pyi
  airflow-stubs/migrations/versions/0086_2_1_4_add_max_active_runs_column_to_dagmodel_.pyi
  airflow-stubs/migrations/versions/0087_2_1_4_add_index_on_state_dag_id_for_queued_.pyi
  airflow-stubs/migrations/versions/0090_2_2_0_rename_concurrency_column_in_dag_table_.pyi
  airflow-stubs/migrations/versions/0094_2_2_3_add_has_import_errors_column_to_dagmodel.pyi
  airflow-stubs/migrations/versions/0096_2_2_4_adding_index_for_dag_id_in_job.pyi
  airflow-stubs/migrations/versions/0098_2_3_0_added_timetable_description_column.pyi
  airflow-stubs/migrations/versions/0101_2_3_0_add_data_compressed_to_serialized_dag.pyi
  airflow-stubs/migrations/versions/0107_2_3_0_add_map_index_to_log.pyi
  airflow-stubs/migrations/versions/0109_2_3_1_add_index_for_event_in_log.pyi
  airflow-stubs/migrations/versions/0111_2_3_3_add_indexes_for_cascade_deletes.pyi
  airflow-stubs/migrations/versions/0117_2_4_0_add_processor_subdir_to_dagmodel_and_.pyi
  airflow-stubs/migrations/versions/0118_2_4_2_add_missing_autoinc_fab.pyi
  airflow-stubs/migrations/versions/0119_2_4_3_add_case_insensitive_unique_constraint_for_username.pyi
  airflow-stubs/migrations/versions/0122_2_5_0_add_is_orphaned_to_datasetmodel.pyi
  airflow-stubs/migrations/versions/0123_2_6_0_add_dttm_index_on_log_table.pyi
  airflow-stubs/migrations/versions/0125_2_6_2_add_onupdate_cascade_to_taskmap.pyi
  airflow-stubs/migrations/versions/0126_2_7_0_add_index_to_task_instance_table.pyi
  airflow-stubs/migrations/versions/0128_2_7_0_add_include_deferred_column_to_pool.pyi
  airflow-stubs/migrations/versions/0129_2_8_0_add_clear_number_to_dag_run.pyi
  airflow-stubs/migrations/versions/0131_2_8_0_make_connection_login_password_text.pyi
  airflow-stubs/migrations/versions/0132_2_8_0_add_processor_subdir_import_error.pyi
  airflow-stubs/migrations/versions/0133_2_8_1_refactor_dag_run_indexes.pyi
  airflow-stubs/migrations/versions/0134_2_9_0_add_rendered_map_index_to_taskinstance.pyi
  airflow-stubs/migrations/versions/0137_2_9_0_adding_adding_max_failure_runs_column_.pyi
  airflow-stubs/migrations/versions/0138_2_9_0_make_xcom_value_to_longblob_for_mysql.pyi
  airflow-stubs/migrations/versions/0139_2_9_0_add_display_name_for_dag_and_task_.pyi
  airflow-stubs/migrations/versions/0141_2_9_2_remove_idx_last_scheduling_decision_.pyi
  airflow-stubs/migrations/versions/0142_2_9_2_fix_inconsistency_between_ORM_and_migration_files.pyi
  airflow-stubs/migrations/versions/0143_2_10_0_add_indexes_on_dag_id_column_in_referencing_tables.pyi
  airflow-stubs/migrations/versions/0144_2_10_0_add_new_executor_field_to_db.pyi
  airflow-stubs/migrations/versions/0145_2_10_0_added_dagpriorityparsingrequest_table.pyi
  airflow-stubs/migrations/versions/0147_2_10_0_add_dataset_alias.pyi
  airflow-stubs/migrations/versions/0148_2_10_0_dataset_alias_dataset_event.pyi
  airflow-stubs/migrations/versions/0149_2_10_0_add_try_number_to_audit_log.pyi
  airflow-stubs/migrations/versions/0150_2_10_0_dataset_alias_dataset.pyi
/tmp/baipp/dist/airflow_stubs-0.0.2.dev5+g9cb55cf-py3-none-any.whl: W002: Wheel contains duplicate files:
  airflow-stubs/migrations/versions/0007_1_6_0_add_dagrun.pyi
  airflow-stubs/migrations/versions/0017_1_7_1_add_task_fails_journal_table.pyi
  airflow-stubs/migrations/versions/0018_1_7_1_add_dag_stats_table.pyi
  airflow-stubs/migrations/versions/0045_1_10_7_add_root_dag_id_to_dag.pyi
  airflow-stubs/migrations/versions/0051_1_10_8_add_dagtags_table.pyi
  airflow-stubs/migrations/versions/0058_1_10_13_increase_length_of_fab_ab_view_menu_.pyi
  airflow-stubs/migrations/versions/0116_2_4_0_add_dag_owner_attributes_table.pyi
  airflow-stubs/migrations/versions/0135_2_9_0_add_run_id_to_audit_log_table_and_change_event_name_length.pyi
  airflow-stubs/migrations/versions/0151_2_10_0_dag_schedule_dataset_alias_reference.pyi
/tmp/baipp/dist/airflow_stubs-0.0.2.dev5+g9cb55cf-py3-none-any.whl: W002: Wheel contains duplicate files:
  airflow-stubs/migrations/versions/0028_1_10_0_add_kubernetes_resource_checkpointing.pyi
  airflow-stubs/migrations/versions/0030_1_10_0_add_kubernetes_scheduler_uniqueness.pyi
/tmp/baipp/dist/airflow_stubs-0.0.2.dev5+g9cb55cf-py3-none-any.whl: W002: Wheel contains duplicate files:
  airflow-stubs/migrations/versions/0031_1_10_0_merge_heads.pyi
  airflow-stubs/migrations/versions/0038_1_10_2_add_sm_dag_index.pyi
  airflow-stubs/migrations/versions/0049_1_10_7_merge_heads.pyi
/tmp/baipp/dist/airflow_stubs-0.0.2.dev5+g9cb55cf-py3-none-any.whl: W002: Wheel contains duplicate files:
  airflow-stubs/migrations/versions/0065_2_0_0_update_schema_for_smart_sensor.pyi
  airflow-stubs/migrations/versions/0089_2_2_0_make_xcom_pkey_columns_non_nullable.pyi
  airflow-stubs/migrations/versions/0112_2_4_0_add_dagwarning_model.pyi
  airflow-stubs/migrations/versions/0115_2_4_0_remove_smart_sensors.pyi
/tmp/baipp/dist/airflow_stubs-0.0.2.dev5+g9cb55cf-py3-none-any.whl: W002: Wheel contains duplicate files:
  airflow-stubs/migrations/versions/0069_2_0_0_add_scheduling_decision_to_dagrun_and_.pyi
  airflow-stubs/migrations/versions/0085_2_1_3_add_queued_at_column_to_dagrun_table.pyi
  airflow-stubs/migrations/versions/0092_2_2_0_add_data_interval_start_end_to_dagmodel_and_dagrun.pyi
  airflow-stubs/migrations/versions/0113_2_4_0_compare_types_between_orm_and_db.pyi
  airflow-stubs/migrations/versions/0120_2_5_0_add_updated_at_to_dagrun_and_ti.pyi
/tmp/baipp/dist/airflow_stubs-0.0.2.dev5+g9cb55cf-py3-none-any.whl: W002: Wheel contains duplicate files:
  airflow-stubs/migrations/versions/0070_2_0_0_fix_mssql_exec_date_rendered_task_instance.pyi
  airflow-stubs/migrations/versions/0095_2_2_4_add_session_table_to_db.pyi
  airflow-stubs/migrations/versions/0127_2_7_0_add_custom_operator_name_column.pyi
  airflow-stubs/migrations/versions/0130_2_8_0_add_owner_display_name_to_audit_log_table.pyi
/tmp/baipp/dist/airflow_stubs-0.0.2.dev5+g9cb55cf-py3-none-any.whl: W002: Wheel contains duplicate files:
  airflow-stubs/migrations/versions/0074_2_0_0_resource_based_permissions.pyi
  airflow-stubs/migrations/versions/0084_2_1_0_resource_based_permissions_for_default_.pyi
/tmp/baipp/dist/airflow_stubs-0.0.2.dev5+g9cb55cf-py3-none-any.whl: W002: Wheel contains duplicate files:
  airflow-stubs/migrations/versions/0097_2_3_0_increase_length_of_email_and_username.pyi
  airflow-stubs/migrations/versions/0106_2_3_0_update_migration_for_fab_tables_to_add_missing_constraints.pyi
  airflow-stubs/migrations/versions/0110_2_3_2_add_cascade_to_dag_tag_foreignkey.pyi
  airflow-stubs/migrations/versions/0124_2_6_0_increase_length_of_user_identifier_columns.pyi
/tmp/baipp/dist/airflow_stubs-0.0.2.dev5+g9cb55cf-py3-none-any.whl: W002: Wheel contains duplicate files:
  airflow-stubs/serialization/serializers/deltalake.pyi
  airflow-stubs/serialization/serializers/iceberg.pyi
```